### PR TITLE
Fix for the player tab crash

### DIFF
--- a/src/main/java/me/travis/wurstplus/mixins/WurstplusMixinGuiPlayerTabOverlay.java
+++ b/src/main/java/me/travis/wurstplus/mixins/WurstplusMixinGuiPlayerTabOverlay.java
@@ -16,6 +16,9 @@ public class WurstplusMixinGuiPlayerTabOverlay {
 
     @Redirect(method = { "renderPlayerlist" }, at = @At(value = "INVOKE", target = "Ljava/util/List;subList(II)Ljava/util/List;"))
     public List<NetworkPlayerInfo> subListHook(final List<NetworkPlayerInfo> list, final int fromIndex, final int toIndex) {
+        if (255 > list.size()) {
+    		return list.subList(fromIndex, list.size() - 1);
+    	}
         return list.subList(fromIndex, 255);
     }
 

--- a/src/main/java/me/travis/wurstplus/mixins/WurstplusMixinGuiPlayerTabOverlay.java
+++ b/src/main/java/me/travis/wurstplus/mixins/WurstplusMixinGuiPlayerTabOverlay.java
@@ -17,7 +17,7 @@ public class WurstplusMixinGuiPlayerTabOverlay {
     @Redirect(method = { "renderPlayerlist" }, at = @At(value = "INVOKE", target = "Ljava/util/List;subList(II)Ljava/util/List;"))
     public List<NetworkPlayerInfo> subListHook(final List<NetworkPlayerInfo> list, final int fromIndex, final int toIndex) {
         if (255 > list.size()) {
-    		return list.subList(fromIndex, list.size() - 1);
+    		return list.subList(fromIndex, list.size());
     	}
         return list.subList(fromIndex, 255);
     }


### PR DESCRIPTION
There is a problem when opening the players list the game crashes because the subList toIndex is higher than the list size.